### PR TITLE
feat: add Traditional Chinese (Taiwan) translation option

### DIFF
--- a/SubFlow/Models/CaptionSettings.swift
+++ b/SubFlow/Models/CaptionSettings.swift
@@ -1,5 +1,22 @@
 import Foundation
 
+/// BCP-47 targets that the Apple Translation framework understands for
+/// English → Chinese. The raw value is what gets written to UserDefaults and
+/// passed to `Locale.Language(identifier:)`, so it must round-trip cleanly.
+enum TranslationTarget: String, CaseIterable, Identifiable {
+    case simplifiedChinese = "zh-Hans"
+    case traditionalChineseTaiwan = "zh-Hant-TW"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .simplifiedChinese: return "简体中文"
+        case .traditionalChineseTaiwan: return "繁體中文（台灣）"
+        }
+    }
+}
+
 struct ASRModel: Identifiable, Hashable {
     let id: String
     let name: String
@@ -42,6 +59,12 @@ final class CaptionSettings {
         didSet { UserDefaults.standard.set(selectedModelId, forKey: "selectedModelId") }
     }
 
+    var translationTarget: TranslationTarget {
+        didSet {
+            UserDefaults.standard.set(translationTarget.rawValue, forKey: "translationTarget")
+        }
+    }
+
     var selectedModel: ASRModel {
         ASRModel.available.first { $0.id == selectedModelId } ?? ASRModel.defaultModel
     }
@@ -61,5 +84,9 @@ final class CaptionSettings {
         } else {
             selectedModelId = ASRModel.defaultModel.id
         }
+
+        let savedTarget = defaults.string(forKey: "translationTarget")
+            .flatMap(TranslationTarget.init(rawValue:))
+        translationTarget = savedTarget ?? .simplifiedChinese
     }
 }

--- a/SubFlow/Services/TranslationService.swift
+++ b/SubFlow/Services/TranslationService.swift
@@ -3,10 +3,10 @@ import Translation
 final class TranslationService: @unchecked Sendable {
     private var session: TranslationSession?
 
-    var configuration: TranslationSession.Configuration {
+    func configuration(target: TranslationTarget) -> TranslationSession.Configuration {
         TranslationSession.Configuration(
             source: .init(identifier: "en"),
-            target: .init(identifier: "zh-Hans")
+            target: .init(identifier: target.rawValue)
         )
     }
 

--- a/SubFlow/SubFlowApp.swift
+++ b/SubFlow/SubFlowApp.swift
@@ -35,6 +35,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setupRemoteControl()
         updateFloatingPanelWithTranslation()
         observePanelWidth()
+        observeTranslationTarget()
         observeDownloadProgress()
 
         viewModel.preloadModel(modelId: settings.selectedModelId)
@@ -115,7 +116,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func updateFloatingPanelWithTranslation() {
-        let config = viewModel.translationService.configuration
+        let config = viewModel.translationService.configuration(
+            target: settings.translationTarget
+        )
         let content = FloatingCaptionView()
             .environment(viewModel)
             .environment(settings)
@@ -179,6 +182,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor [weak self] in
                 self?.updatePanelFrame()
                 self?.observePanelWidth()
+            }
+        }
+    }
+
+    /// Rebuild the floating panel's hosting view when the user picks a new
+    /// Chinese variant. `.translationTask(config)` is pinned to the view at
+    /// mount time; replacing the NSHostingView is the cleanest way to force
+    /// SwiftUI to request a new TranslationSession for the new BCP-47 target.
+    private func observeTranslationTarget() {
+        withObservationTracking {
+            let _ = settings.translationTarget
+        } onChange: {
+            Task { @MainActor [weak self] in
+                self?.updateFloatingPanelWithTranslation()
+                self?.observeTranslationTarget()
             }
         }
     }

--- a/SubFlow/Views/SettingsView.swift
+++ b/SubFlow/Views/SettingsView.swift
@@ -58,9 +58,25 @@ struct SettingsView: View {
                         .foregroundStyle(.orange)
                 }
             }
+
+            Section("Translation Language") {
+                Picker("Chinese variant", selection: $settings.translationTarget) {
+                    ForEach(TranslationTarget.allCases) { target in
+                        Text(target.displayName).tag(target)
+                    }
+                }
+                .pickerStyle(.radioGroup)
+                .disabled(viewModel.isRecording)
+
+                if viewModel.isRecording {
+                    Text("Stop recording before switching languages")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+            }
         }
         .formStyle(.grouped)
-        .frame(width: 450, height: 320)
+        .frame(width: 450, height: 420)
         .onChange(of: settings.selectedModelId) { _, newModelId in
             guard !viewModel.isRecording, !viewModel.isLoading else { return }
             viewModel.switchModel(to: newModelId)

--- a/SubFlowTests/CaptionSettingsTests.swift
+++ b/SubFlowTests/CaptionSettingsTests.swift
@@ -115,3 +115,66 @@ import Foundation
     // Cleanup
     defaults.removeObject(forKey: "fontSize")
 }
+
+// MARK: - TranslationTarget
+
+@Test func translationTargetRawValuesAreBCP47() {
+    #expect(TranslationTarget.simplifiedChinese.rawValue == "zh-Hans")
+    #expect(TranslationTarget.traditionalChineseTaiwan.rawValue == "zh-Hant-TW")
+}
+
+@Test func translationTargetAllCasesContainsBoth() {
+    let ids = TranslationTarget.allCases.map(\.rawValue)
+    #expect(ids.contains("zh-Hans"))
+    #expect(ids.contains("zh-Hant-TW"))
+}
+
+@Test func translationTargetHasDisplayNames() {
+    // Display names are for human readers; verify non-empty and distinct so
+    // the Settings picker never shows two identical rows.
+    let names = TranslationTarget.allCases.map(\.displayName)
+    #expect(names.allSatisfy { !$0.isEmpty })
+    #expect(Set(names).count == names.count)
+}
+
+@Test @MainActor func captionSettingsDefaultTranslationTargetIsSimplified() {
+    let defaults = UserDefaults.standard
+    defaults.removeObject(forKey: "translationTarget")
+
+    let settings = CaptionSettings()
+    #expect(settings.translationTarget == .simplifiedChinese)
+}
+
+@Test @MainActor func captionSettingsPersistsTranslationTarget() {
+    let defaults = UserDefaults.standard
+    defaults.removeObject(forKey: "translationTarget")
+
+    let settings = CaptionSettings()
+    settings.translationTarget = .traditionalChineseTaiwan
+    #expect(defaults.string(forKey: "translationTarget") == "zh-Hant-TW")
+
+    // Cleanup
+    defaults.removeObject(forKey: "translationTarget")
+}
+
+@Test @MainActor func captionSettingsLoadsPersistedTranslationTarget() {
+    let defaults = UserDefaults.standard
+    defaults.set("zh-Hant-TW", forKey: "translationTarget")
+
+    let settings = CaptionSettings()
+    #expect(settings.translationTarget == .traditionalChineseTaiwan)
+
+    // Cleanup
+    defaults.removeObject(forKey: "translationTarget")
+}
+
+@Test @MainActor func captionSettingsInvalidTranslationTargetFallsBackToDefault() {
+    let defaults = UserDefaults.standard
+    defaults.set("ja-JP", forKey: "translationTarget")
+
+    let settings = CaptionSettings()
+    #expect(settings.translationTarget == .simplifiedChinese)
+
+    // Cleanup
+    defaults.removeObject(forKey: "translationTarget")
+}

--- a/SubFlowTests/EndToEndTests.swift
+++ b/SubFlowTests/EndToEndTests.swift
@@ -134,7 +134,7 @@ import AppKit
 
 @Test func translationServiceLanguagePairEndToEnd() {
     let service = TranslationService()
-    let config = service.configuration
+    let config = service.configuration(target: .simplifiedChinese)
     #expect(config.source?.languageCode?.identifier == "en")
     #expect(config.target?.languageCode?.identifier == "zh")
     #expect(config.target?.script?.identifier == "Hans")

--- a/SubFlowTests/TranslationServiceTests.swift
+++ b/SubFlowTests/TranslationServiceTests.swift
@@ -13,10 +13,19 @@ import Foundation
     }
 }
 
-@Test func translationServiceConfigurationIsEnglishToChinese() {
+@Test func translationServiceConfigurationSimplifiedChinese() {
     let service = TranslationService()
-    let config = service.configuration
+    let config = service.configuration(target: .simplifiedChinese)
     #expect(config.source?.languageCode?.identifier == "en")
     #expect(config.target?.languageCode?.identifier == "zh")
     #expect(config.target?.script?.identifier == "Hans")
+}
+
+@Test func translationServiceConfigurationTraditionalChineseTaiwan() {
+    let service = TranslationService()
+    let config = service.configuration(target: .traditionalChineseTaiwan)
+    #expect(config.source?.languageCode?.identifier == "en")
+    #expect(config.target?.languageCode?.identifier == "zh")
+    #expect(config.target?.script?.identifier == "Hant")
+    #expect(config.target?.region?.identifier == "TW")
 }


### PR DESCRIPTION
## Summary

Lets users switch the translation target from Simplified Chinese (`zh-Hans`) to Traditional Chinese / Taiwan (`zh-Hant-TW`) so Taiwan readers get wording that matches their daily reading (影片 vs 视频, 軟體 vs 软件). Choice persists via UserDefaults; defaults to Simplified so existing users see no change.

Main wiring:
- New `TranslationTarget` enum in `CaptionSettings.swift` with BCP-47 raw values
- `TranslationService.configuration(target:)` replaces the hardcoded no-arg variant
- New Settings section with radio-group picker, disabled during recording (mirrors the ASR model-switch UX)
- `AppDelegate.observeTranslationTarget()` rebuilds the floating panel's `NSHostingView` on change so the pinned `.translationTask(config)` re-fires with the new target

## Related Issue

Closes #6

## Test Instructions

```bash
xcodebuild test -project SubFlow.xcodeproj -scheme SubFlowTests -destination 'platform=macOS'
# Expected: 92 tests pass (+8 vs main)
```

Manual smoke test (user-verified):

1. `open SubFlow.xcodeproj` → ⌘R
2. Menu bar → Settings… → "Translation Language" → pick "繁體中文（台灣）"
3. Start recording, play English audio → captions should render in Traditional Chinese
4. Quit + relaunch → setting persists

## Checklist

- [x] Version / deps: no new Swift packages, no `project.yml` changes beyond the files list
- [x] Tests: 92/92 passing locally (8 new: 3 enum, 4 settings persistence, 2 service configuration; net +1 in TranslationService file after replacing the old no-arg test)
- [x] Back-compat: existing users keep `zh-Hans` on first launch; invalid stored values fall back to default
- [x] UX parity: picker disabled during recording, same pattern as ASR model switch
- [x] CI: N/A — repo has no `.github/workflows/`; verified locally via `xcodebuild test`