### PR TITLE
chore: align MARKETING_VERSION with fresh v1.0.0 release

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -20,7 +20,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.pinechou.SubFlow
-        MARKETING_VERSION: "1.1.0"
+        MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         CODE_SIGN_ENTITLEMENTS: SubFlow/Resources/SubFlow.entitlements


### PR DESCRIPTION
## Summary

Change `project.yml` MARKETING_VERSION from `"1.1.0"` → `"1.0.0"` to match the fresh v1.0.0 release we're about to cut. Prep work for the release reset — see issue #8.

## Related Issue

Closes #8

## Test Instructions

```bash
xcodegen generate
xcodebuild test -project SubFlow.xcodeproj -scheme SubFlowTests -destination 'platform=macOS'
# Expected: 92 tests pass (same as before — this is metadata-only)
```

## Checklist

- [x] Version / deps: metadata-only, no code change
- [x] Tests: unaffected (verified locally)
- [x] CI: N/A — repo has no `.github/workflows/`